### PR TITLE
Add "See also" links

### DIFF
--- a/db/migrations/20201209174006-create-table-link.sql
+++ b/db/migrations/20201209174006-create-table-link.sql
@@ -1,0 +1,10 @@
+
+-- up
+CREATE TABLE link (
+  source integer not null references binding(id),
+  target integer not null references binding(id),
+  PRIMARY KEY (source, target)
+);
+
+-- down
+DROP TABLE link;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,18 +1,18 @@
-CREATE TABLE schema_migrations (version text primary key)
+CREATE TABLE schema_migrations (version text primary key);
 CREATE TABLE account (
   id integer primary key,
   email text,
   access_token text not null,
   created_at integer not null default(strftime('%s', 'now')),
   updated_at integer
-, login text not null default '')
+, login text not null default '');
 CREATE TABLE package (
   id integer primary key,
   name text not null,
   url text not null,
   created_at integer not null default(strftime('%s', 'now')),
   updated_at integer
-)
+);
 CREATE TABLE binding (
   id integer primary key,
   name text not null,
@@ -20,7 +20,7 @@ CREATE TABLE binding (
   package_id integer references package(id),
   created_at integer not null default(strftime('%s', 'now')),
   updated_at integer
-)
+);
 CREATE TABLE example (
   id integer primary key,
   body text not null,
@@ -28,4 +28,9 @@ CREATE TABLE example (
   account_id integer not null references account(id),
   created_at integer not null default(strftime('%s', 'now')),
   updated_at integer
-)
+);
+CREATE TABLE link (
+  source integer not null references binding(id),
+  target integer not null references binding(id),
+  PRIMARY KEY (source, target)
+);

--- a/project.janet
+++ b/project.janet
@@ -1,12 +1,15 @@
 (declare-project
   :name "janetdocs"
-  :description ""
-  :dependencies ["https://github.com/joy-framework/joy"
-                 "https://github.com/joy-framework/http"]
-  :author ""
-  :license ""
-  :url ""
-  :repo "")
+  :description "JanetDocs is a community documentation site for the Janet programming language"
+  :dependencies ["https://github.com/janet-lang/sqlite3"
+                 "https://github.com/joy-framework/dotenv"
+                 "https://github.com/joy-framework/http"
+                 "https://github.com/joy-framework/joy"]
+
+  :author "Sean Walker"
+  :license "MIT"
+  :url "https://janetdocs.com"
+  :repo "https://github.com/swlkr/janetdocs")
 
 (declare-executable
   :name "janetdocs"

--- a/public/app.css
+++ b/public/app.css
@@ -71,3 +71,7 @@ h2[responsive] {
 textarea {
   font-family: monospace;
 }
+
+a.see-also {
+  margin-left: 10px;
+}

--- a/routes/examples.janet
+++ b/routes/examples.janet
@@ -24,6 +24,27 @@
        [:a {:href (string "https://github.com/" (ex :login))}
         (ex :login)]]])])
 
+(defn format-see-also-link [link]
+  (let [name (link :name)]
+    [:a {
+         :href (string "/" name)
+         :class "see-also"}
+     name])) 
+
+(defn see-also [binding-id]
+  (let [links (db/query `select 
+                          binding.name
+                         from link
+                         join 
+                           binding on link.target = binding.id
+                         where 
+                           link.source = ?
+                         order 
+                           by binding.name`
+                        [binding-id])]
+    (if (empty? links) 
+     []
+     [:hstack [:strong "See also:"] (map format-see-also-link links)])))
 
 (defn index [request]
   (def {:binding binding :session session} request)
@@ -35,6 +56,7 @@
                           [(binding :id)]))
 
   [:vstack {:spacing "xl" :x-data "{ editing: false, add: true, adding: false, examples: {} }" :@cancel-new "editing = false" :@cancel-edit "add = true" :@edit-example "add = false"}
+   (see-also (binding :id))
    [:hstack
     [:strong (string (length examples) (singularize " examples" (length examples)))]
     [:spacer]

--- a/seed.janet
+++ b/seed.janet
@@ -17,12 +17,40 @@
 
 (joy/db/connect)
 
+(defn find-binding-id [name]
+  (let [binding (joy/db/find-by :binding :where {:name name})]
+   (if binding (binding :id) nil)))
+   
+
 (loop [d :in alldocs]
-  (def b (joy/db/find-by :binding :where {:name (d :name)}))
-  (if b
-    (joy/db/update :binding b {:docstring (d :docstring) # fix shadowed bindings and ? url problem
-                               :name (d :name)})
-    (joy/db/insert :binding {:name (d :name)
-                             :docstring (d :docstring)})))
+  (let [b (find-binding-id (d :name))]
+    (if b
+      (joy/db/update :binding b {:docstring (d :docstring) # fix shadowed bindings and ? url problem
+                                 :name (d :name)})
+      (joy/db/insert :binding {:name (d :name)
+                               :docstring (d :docstring)}))))
+
+# Links that appear under "See also"
+(def links
+  [
+   ["%" "mod"]
+   ["each" "eachk" "eachp"]
+   ["file/close" "file/open"]
+   ["file/open" "file/close"]
+   ["file/read" "slurp"]
+   ["mod" "%"]
+   ["print" "printf" "pp"]
+   ["prompt" "return"]
+   ["return" "prompt"]])
+
+(each lnk links
+  (let [src (first lnk)
+        targets (drop 1 lnk)]
+    (each t targets
+      (let [source (find-binding-id src)
+            target (find-binding-id t)
+            exists (joy/db/find-by :link :where {:source (string source) :target (string target)})]
+        (if (nil? exists)
+            (joy/db/insert :link {:source source :target target}))))))
 
 (joy/db/disconnect)


### PR DESCRIPTION
Adds a new table `link` that keeps track of links between bindings.

Links are displayed under "See also" above the user contributed examples.

In future be extended to keep track of different types of links (such as 'deprecated by' or
'alias for'). This is why it has the relative generic name links.

The entries for the new table are created via a list in `seed.janet`.
More entries should be created in the future...

I also added semicolons to `schema.sql` in order to be able to do `sqlite new.db < db/schema.sql`. 
Was not sure whether this conflicts with any other tooling...

And the PR includes also some small changes to the `project.janet`. I added dependencies that I needed to get it to run and a I updated the license and author field. These changes are independent of the "see also" change and if you prefer I can leave them out of this PR.
