### PR TITLE
delete .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Use an approximate language for syntax highlighting (clojure is pretty close)
-*.janet linguist-language=clojure


### PR DESCRIPTION
GitHub officially recognizes Janet now, so there's no need to pretend to be Clojure anymore.